### PR TITLE
Add project README with session schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# PayNet AI Working Group
+
+This repository hosts materials and resources for the PayNet AI Working Group (AIWG). The AIWG brings together teams across PayNet to present and share knowledge on the latest artificial intelligence concepts, tools, and practices.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Explore the Jupyter notebooks for each session to follow along with demonstrations and examples.
+
+## Session Schedule
+
+| Session | Title | Team | Date | Location |
+|--------:|-------|------|------|----------|
+| 01 | Building a Security Deep Research Agent | R&D | 12 September 2025 | Bangsar South |
+| 02 | What is Model Context Protocol (MCP)? Build and Secure your MCP servers | R&D | 23 September 2025 | Bangsar South |
+| 03 | Automated Red-teaming of AI models & endpoints | R&D | 7 October 2025 | MURUD |
+| 04 | Vibe Coding is the future | App Engineering | 21 October 2025 | Bangsar South |
+| 05 | Using Uncensored Models for Cybersecurity Tasks | R&D | 4 November 2025 | Bangsar South |
+| 06 | AI Driven Code Review & Security Testing | ITS | 18 November 2025 | Bangsar South |
+
+## Contributing
+
+Contributions in the form of session materials, notebooks, or improvements are welcome. Please fork the repository and open a pull request with your changes.
+
+## License
+
+This project is licensed under the terms of the [LICENSE](LICENSE) file.
+


### PR DESCRIPTION
## Summary
- create initial README with project overview
- document setup instructions and six-session schedule

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3bcea8da4832c9f4e7e5be8b07522