### PR TITLE
Update README to cover MCP session materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository hosts materials and resources for the PayNet AI Working Group (A
    ```bash
    pip install -r requirements.txt
    ```
-2. Explore the Jupyter notebooks for each session to follow along with demonstrations and examples.
+2. Explore the Jupyter notebooks and supporting source files for each session to follow along with demonstrations and examples.
+3. Session-specific projects may include their own `requirements.txt` files. Install them in an isolated environment when you are ready to experiment with that session's code.
 
 ## Session 1: Building a Security Deep Research Agent
 
@@ -26,6 +27,32 @@ To run the notebook locally or in Google&nbsp;Colab:
 3. Launch Jupyter or open the notebook in Colab and execute the cells sequentially.
 
 The resulting agent showcases how lightweight tools and memory can be combined to build a security-focused deep research assistant.
+
+## Session 2: What is Model Context Protocol (MCP)?
+
+The materials for Session&nbsp;2 live in [`AIWorkingGroup_02_MCP/`](AIWorkingGroup_02_MCP/). This session introduces the [Model Context Protocol](https://modelcontextprotocol.io) and demonstrates how to build, secure, and interact with a simple MCP server.
+
+### Key Components
+
+* [`mcp_server.py`](AIWorkingGroup_02_MCP/mcp_server.py) – a weather-themed MCP server powered by [`FastMCP`](https://github.com/modelcontextprotocol/fastmcp). It exposes tools such as `get_temperature` and `get_windspeed` that call the Open-Meteo APIs, and includes commented code illustrating how to enable token-based authentication.
+* [`src/auth.py`](AIWorkingGroup_02_MCP/src/auth.py) – includes a `SimpleTokenVerifier` class demonstrating optional bearer-token validation when running the server in authenticated mode.
+* [`mcp_client.ipynb`](AIWorkingGroup_02_MCP/mcp_client.ipynb) – walks through connecting to the MCP server, invoking its tools, and observing the responses.
+
+### Running the server
+
+1. Install the session-specific dependencies:
+   ```bash
+   cd AIWorkingGroup_02_MCP
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   python mcp_server.py
+   ```
+   The default configuration runs without authentication using the streamable HTTP transport. Uncomment the provided `FastMCP` configuration and supply a valid token (for example, `sk-1234`) to explore the optional authentication flow.
+3. Open the accompanying notebook or your preferred MCP-compatible client to connect to the running server and exercise the tools.
+
+The project folder also contains an example `output.log` showcasing sample server interactions.
 
 ## Session Schedule
 


### PR DESCRIPTION
## Summary
- expand the main README with guidance on navigating session resources and per-session dependencies
- add documentation for the new Model Context Protocol session, highlighting its key files and how to run the sample MCP server

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d5f9c92888832ca64ea454025e3370